### PR TITLE
[postgresql] fix coredump

### DIFF
--- a/dbd/postgresql/statement.c
+++ b/dbd/postgresql/statement.c
@@ -411,7 +411,7 @@ int dbd_postgresql_statement_create(lua_State *L, connection_t *conn, const char
 
     if (!result) {
         lua_pushnil(L);
-        lua_pushfstring(L, DBI_ERR_ALLOC_STATEMENT, PQerrorMessage(statement->conn->postgresql));
+        lua_pushfstring(L, DBI_ERR_ALLOC_STATEMENT, PQerrorMessage(conn->postgresql));
         return 2;
     }
     


### PR DESCRIPTION
> Program terminated with signal SIGSEGV, Segmentation fault.
> #0  dbd_postgresql_statement_create (L=0x161c010, conn=0x1809288, sql_query=<optimised out>) at dbd/postgresql/statement.c:414
> 414             lua_pushfstring(L, DBI_ERR_ALLOC_STATEMENT, PQerrorMessage(statement->conn->postgresql));
> (gdb) p statement
> $1 = (statement_t *) 0x0
> (gdb) p conn
> $1 = (connection_t *) 0x1809288
> (gdb) p conn->postgresql
> $2 = (PGconn *) 0x18092a0