### PR TITLE
Oracle bugfixes and improvements

### DIFF
--- a/dbd/oracle/connection.c
+++ b/dbd/oracle/connection.c
@@ -210,7 +210,7 @@ static int connection_rollback(lua_State *L) {
  * last_id = connection:last_id()
  */
 static int connection_lastid(lua_State *L) {
-    luaL_error(L, DBI_ERR_NOT_IMPLEMENTED, DBD_POSTGRESQL_CONNECTION, "last_id");
+    luaL_error(L, DBI_ERR_NOT_IMPLEMENTED, DBD_ORACLE_CONNECTION, "last_id");
     return 0;
 }
 

--- a/dbd/oracle/statement.c
+++ b/dbd/oracle/statement.c
@@ -167,12 +167,6 @@ int statement_close(lua_State *L) {
  */
 static int statement_columns(lua_State *L) {
     statement_t *statement = (statement_t *)luaL_checkudata(L, 1, DBD_ORACLE_STATEMENT);
-    int rc;
-
-    bindparams_t *bind;
-
-    char errbuf[100];
-    int errcode;
 
     int i;
     int d = 1;
@@ -364,9 +358,7 @@ int statement_execute(lua_State *L) {
  * must be called after an execute
  */
 static int statement_fetch_impl(lua_State *L, statement_t *statement, int named_columns) {
-    int rc;
     sword status;
-    int i;
     bindparams_t *bind;
 
     char errbuf[100];


### PR DESCRIPTION
Removed unused vars; fixed copypasta constant from POSTGRESQL code. Performance improved roughly two orders of magnitude for fairly arbitrary multi-row tests by turning on a 1MB prefetch cache. See comment in 411b774 about TO_CHAR conversion size and truncation...