### PR TITLE
Fix memory leak in statement:execute by calling PQclear

### DIFF
--- a/dbd/postgresql/statement.c
+++ b/dbd/postgresql/statement.c
@@ -218,7 +218,12 @@ cleanup:
         lua_pushfstring(L, DBI_ERR_BINDING_EXEC, PQresultErrorMessage(result));
         return 2;
     }
-    
+
+    if (statement->result) {
+        status = PQresultStatus (statement->result);
+	if (status == PGRES_COMMAND_OK || status == PGRES_TUPLES_OK)
+            PQclear (statement->result);
+    }
     statement->result = result;
 
     lua_pushboolean(L, 1);


### PR DESCRIPTION
There is a memory leak in statement:execute because the old result is not cleared. So the script keeps on hogging memory.
Check old result and if it is OK status then call PQclear before assigning new result to statement->result.