### PR TITLE
Unbreak building against MariaDB 5.5

### DIFF
--- a/dbd/mysql/dbd_mysql.h
+++ b/dbd/mysql/dbd_mysql.h
@@ -9,7 +9,7 @@
 #define DBD_MYSQL_CONNECTION    "DBD.MySQL.Connection"
 #define DBD_MYSQL_STATEMENT     "DBD.MySQL.Statement"
 
-#ifndef LIBMARIADB
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80001
 #define my_bool bool
 #endif
 


### PR DESCRIPTION
As mentioned in the compilation notes of MySQL 8.0.1, `my_bool` was [removed](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html).

However, building LuaDBI 0.7.3 against MariaDB 5.5 on CentOS 7 fails like this:

```
In file included from dbd/mysql/statement.c:1:0:
dbd/mysql/statement.c: In function 'statement_execute': dbd/mysql/dbd_mysql.h:13:17: error: 'bool' undeclared (first use in this function)
 #define my_bool bool
                 ^
dbd/mysql/statement.c:230:23: note: in expansion of macro 'my_bool'
    bind[i].is_null = (my_bool*)0;
                       ^
dbd/mysql/dbd_mysql.h:13:17: note: each undeclared identifier is reported only once for each function it appears in
 #define my_bool bool
                 ^
dbd/mysql/statement.c:230:23: note: in expansion of macro 'my_bool'
    bind[i].is_null = (my_bool*)0;
                       ^
dbd/mysql/statement.c:230:31: error: expected expression before ')' token
    bind[i].is_null = (my_bool*)0;
                               ^
dbd/mysql/statement.c:258:31: error: expected expression before ')' token
    bind[i].is_null = (my_bool*)0;
                               ^
dbd/mysql/statement.c:269:31: error: expected expression before ')' token
    bind[i].is_null = (my_bool*)0;
                               ^
```

Suggested code change (tested on Fedora and EPEL for CentOS/RHEL/Rocky Linux against MariaDB 5.5 and MariaDB Connector/C) is the same like at:

- [DBD::MariaDB](https://github.com/perl5-dbi/DBD-MariaDB/blob/master/dbdimp.h#L327)
- [DBD::mysql](https://fossies.org/diffs/DBD-mysql/4.051_vs_5.001/dbdimp.h-diff.html)
- [libnss-mysql](https://cgit.freebsd.org/ports/commit/?id=1709b49e199d5ca6c4059585ff56668649e6c0ef)